### PR TITLE
Fix sticky header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,7 +42,7 @@ const Header = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+    <header className="fixed top-0 inset-x-0 z-50 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
       <div className="container mx-auto px-4">
         {/* Top Bar */}
         <div className="flex items-center justify-between py-2 text-sm border-b border-border/50">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -56,7 +56,7 @@ const Index = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pt-28 md:pt-32">
       <Header />
       <HeroSection />
       


### PR DESCRIPTION
## Summary
- fix header positioning so it stays fixed on top
- add padding-top to page content so the header doesn't overlap

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c5dbd8288320bc32dc9735559de2