### PR TITLE
Fix category navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import CategoryPage from "./pages/CategoryPage";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/categories/:categoryKey" element={<CategoryPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/CategoryGrid.tsx
+++ b/src/components/CategoryGrid.tsx
@@ -1,6 +1,7 @@
 
 import { Card, CardContent } from "@/components/ui/card";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { 
   Car,
   Building,
@@ -56,13 +57,19 @@ const CategoryGrid = () => {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
           {featuredCategories.map((category, index) => (
-            <Card key={category.name} className="category-card group" style={{animationDelay: `${index * 0.1}s`}}>
-              <CardContent className="p-6 text-center">
-                <category.icon className="category-icon mx-auto group-hover:text-primary transition-colors" />
-                <h3 className="font-semibold text-lg mb-2">{t(`categories.list.${category.key}`)}</h3>
-                <p className="text-muted-foreground">{category.count} {t('categories.items')}</p>
-              </CardContent>
-            </Card>
+            <Link
+              to={`/categories/${category.key}`}
+              key={category.key}
+              className="group"
+            >
+              <Card className="category-card" style={{ animationDelay: `${index * 0.1}s` }}>
+                <CardContent className="p-6 text-center">
+                  <category.icon className="category-icon mx-auto group-hover:text-primary transition-colors" />
+                  <h3 className="font-semibold text-lg mb-2">{t(`categories.list.${category.key}`)}</h3>
+                  <p className="text-muted-foreground">{category.count} {t('categories.items')}</p>
+                </CardContent>
+              </Card>
+            </Link>
           ))}
         </div>
 
@@ -73,14 +80,20 @@ const CategoryGrid = () => {
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-          {otherCategories.map((category, index) => (
-            <Card key={category.key} className="category-card text-center p-4 hover:border-primary/50">
-              <CardContent className="p-2">
-                <category.icon className="w-8 h-8 text-accent mx-auto mb-2" />
-                <h4 className="font-medium text-sm mb-1">{t(`categories.list.${category.key}`)}</h4>
-                <p className="text-xs text-muted-foreground">{category.count}</p>
-              </CardContent>
-            </Card>
+          {otherCategories.map(category => (
+            <Link
+              to={`/categories/${category.key}`}
+              key={category.key}
+              className="group"
+            >
+              <Card className="category-card text-center p-4 hover:border-primary/50">
+                <CardContent className="p-2">
+                  <category.icon className="w-8 h-8 text-accent mx-auto mb-2 group-hover:text-primary transition-colors" />
+                  <h4 className="font-medium text-sm mb-1">{t(`categories.list.${category.key}`)}</h4>
+                  <p className="text-xs text-muted-foreground">{category.count}</p>
+                </CardContent>
+              </Card>
+            </Link>
           ))}
         </div>
       </div>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -1,0 +1,24 @@
+import Header from "@/components/Header";
+import { useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+const CategoryPage = () => {
+  const { categoryKey } = useParams<{ categoryKey: string }>();
+  const { t } = useTranslation();
+
+  const displayName = categoryKey
+    ? t(`categories.list.${categoryKey}`)
+    : t("categories.all");
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <div className="container mx-auto px-4 py-12">
+        <h2 className="text-3xl font-bold mb-4">{displayName}</h2>
+        <p className="text-muted-foreground">{t('categories.allSubtitle')}</p>
+      </div>
+    </div>
+  );
+};
+
+export default CategoryPage;


### PR DESCRIPTION
## Summary
- make category cards link to routes
- add placeholder CategoryPage
- register `/categories/:categoryKey` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c8c281088320992dda21b9a4badc