### PR TITLE
Update dark mode palette and sticky header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,7 +42,7 @@ const Header = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+    <header className="sticky top-0 z-50 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b transition-colors">
       <div className="container mx-auto px-4">
         {/* Top Bar */}
         <div className="flex items-center justify-between py-2 text-sm border-b border-border/50">

--- a/src/index.css
+++ b/src/index.css
@@ -45,17 +45,18 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
+    /* Deep green background for dark mode */
+    --background: 173 71% 12%;
     --foreground: 210 40% 98%;
 
-    --card: 222.2 84% 4.9%;
+    --card: 173 71% 12%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 222.2 84% 4.9%;
+    --popover: 173 71% 12%;
     --popover-foreground: 210 40% 98%;
 
-    /* Lighten primary in dark mode for better contrast */
-    --primary: 173 71% 35%;
+    /* Use the same deep green for primary elements */
+    --primary: 173 71% 12%;
     --primary-foreground: 210 40% 98%;
 
     --secondary: 217.2 32.6% 17.5%;
@@ -72,9 +73,9 @@
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 173 71% 35%;
+    --ring: 173 71% 12%;
 
-    --makancom-green: 173 71% 7%;
+    --makancom-green: 173 71% 12%;
     --makancom-gold: 45 100% 51%;
     --makancom-silver: 210 14% 60%;
     --makancom-dark-green: 173 71% 2%;


### PR DESCRIPTION
## Summary
- tweak dark mode colors so background and buttons use deep green
- keep header visible with sticky positioning

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869d0b1f9f8832093bd62f209498aef