### PR TITLE
Improve header visibility and dark mode styling

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,19 +42,21 @@ const Header = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b transition-colors">
+    <header className="sticky top-0 left-0 right-0 z-50 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b transition-colors">
       <div className="container mx-auto px-4">
         {/* Top Bar */}
         <div className="flex items-center justify-between py-2 text-sm border-b border-border/50">
           <div className="flex items-center gap-4">
-            <span className="text-muted-foreground">{t('header.welcome')}</span>
+            <span className="text-muted-foreground text-outline-gold">
+              {t('header.welcome')}
+            </span>
           </div>
           <div className="flex items-center gap-4">
             <Button
               variant="ghost"
               size="sm"
               onClick={toggleLanguage}
-              className="flex items-center gap-2"
+              className="flex items-center gap-2 text-outline-gold"
             >
               <Globe className="w-4 h-4" />
               {language === 'en' ? t('language.arabic') : t('language.english')}
@@ -63,6 +65,7 @@ const Header = () => {
               variant="ghost"
               size="sm"
               onClick={toggleTheme}
+              className="text-outline-gold"
             >
               {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
             </Button>
@@ -74,7 +77,9 @@ const Header = () => {
           {/* Logo */}
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2">
-              <h1 className="text-3xl font-bold text-primary">Makancom</h1>
+              <h1 className="text-3xl font-bold text-primary text-outline-gold">
+                Makancom
+              </h1>
               <GoldStars size={16} />
             </div>
           </div>
@@ -87,8 +92,8 @@ const Header = () => {
                 placeholder={t('header.searchPlaceholder')}
                 className="pl-10 pr-4 py-3 text-lg rounded-full border-2 border-primary/20 focus:border-primary"
               />
-              <Button 
-                className="absolute right-2 top-1/2 transform -translate-y-1/2 rounded-full px-6 bg-primary hover:bg-primary/90"
+              <Button
+                className="absolute right-2 top-1/2 transform -translate-y-1/2 rounded-full px-6 bg-primary hover:bg-primary/90 text-outline-gold"
               >
                 {t('header.search')}
               </Button>
@@ -112,11 +117,11 @@ const Header = () => {
             </Button>
 
             <div className="flex items-center gap-2">
-              <Button variant="outline" className="flex items-center gap-2">
+              <Button variant="outline" className="flex items-center gap-2 text-outline-gold">
                 <User className="w-4 h-4" />
                 {t('header.signIn')}
               </Button>
-              <Button className="bg-primary hover:bg-primary/90">
+              <Button className="bg-primary hover:bg-primary/90 text-outline-gold">
                 {t('header.signUp')}
               </Button>
             </div>

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -79,10 +79,10 @@ const SearchFilters = ({
         >
           {t('header.search')}
         </Button>
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={() => setShowFilters(!showFilters)}
-          className="rounded-full px-6"
+          className="rounded-full px-6 text-primary dark:text-primary-foreground"
         >
           <Filter className="w-4 h-4 mr-2" />
           {t('search.filters')}

--- a/src/index.css
+++ b/src/index.css
@@ -105,4 +105,8 @@
   .category-icon {
     @apply w-12 h-12 text-accent mb-4;
   }
+
+  .text-outline-gold {
+    text-shadow: 0 0 2px #FFD700;
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,6 +24,7 @@ import CategoryGrid from "@/components/CategoryGrid";
 import FeaturedProducts from "@/components/FeaturedProducts";
 import HeroSection from "@/components/HeroSection";
 import SearchFilters from "@/components/SearchFilters";
+import GoldStars from "@/components/GoldStars";
 
 const Index = () => {
   const { t } = useTranslation();
@@ -84,11 +85,7 @@ const Index = () => {
             <div>
               <div className="flex items-center gap-2 mb-4">
                 <h3 className="text-2xl font-bold">Makancom</h3>
-                <div className="flex gap-1">
-                  <div className="w-2 h-2 bg-accent rounded-full"></div>
-                  <div className="w-2 h-2 bg-accent rounded-full"></div>
-                  <div className="w-2 h-2 bg-accent rounded-full"></div>
-                </div>
+                <GoldStars size={12} />
               </div>
               <p className="text-primary-foreground/80">
                 {t('footer.trust')}


### PR DESCRIPTION
## Summary
- make header sticky across the full width
- add reusable `.text-outline-gold` style
- highlight header texts with golden outline
- tweak SearchFilters button colors
- replace footer dots with `GoldStars`

## Testing
- `npm run lint` *(fails: react-refresh only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869d36044f883208ca4e47192203932