### PR TITLE
Fix header buttons and add placeholder modals

### DIFF
--- a/src/components/CartSidebar.tsx
+++ b/src/components/CartSidebar.tsx
@@ -1,0 +1,25 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { useTranslation } from "react-i18next";
+
+interface CartSidebarProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const CartSidebar = ({ open, onOpenChange }: CartSidebarProps) => {
+  const { t } = useTranslation();
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-80 sm:max-w-sm">
+        <SheetHeader>
+          <SheetTitle>Cart</SheetTitle>
+        </SheetHeader>
+        <div className="mt-4 text-sm text-muted-foreground">
+          {t('header.welcome')} - Cart placeholder.
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default CartSidebar;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import GoldStars from "./GoldStars";
+import SignInModal from "./SignInModal";
+import SignUpModal from "./SignUpModal";
+import CartSidebar from "./CartSidebar";
+import NotificationsModal from "./NotificationsModal";
 import { 
   Search, 
   User, 
@@ -25,6 +29,10 @@ const Header = () => {
   const { t, i18n } = useTranslation();
   const [isDark, setIsDark] = useState(false);
   const [language, setLanguage] = useState(i18n.language || 'en');
+  const [isSignInOpen, setSignInOpen] = useState(false);
+  const [isSignUpOpen, setSignUpOpen] = useState(false);
+  const [isCartOpen, setCartOpen] = useState(false);
+  const [isNotificationsOpen, setNotificationsOpen] = useState(false);
 
   useEffect(() => {
     document.documentElement.lang = language;
@@ -97,14 +105,24 @@ const Header = () => {
 
           {/* Actions */}
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" className="relative">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative cursor-pointer"
+              onClick={() => setNotificationsOpen(true)}
+            >
               <Bell className="w-5 h-5" />
               <Badge className="absolute -top-2 -right-2 w-5 h-5 flex items-center justify-center p-0 bg-destructive text-xs">
                 3
               </Badge>
             </Button>
-            
-            <Button variant="ghost" size="icon" className="relative">
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative cursor-pointer"
+              onClick={() => setCartOpen(true)}
+            >
               <ShoppingCart className="w-5 h-5" />
               <Badge className="absolute -top-2 -right-2 w-5 h-5 flex items-center justify-center p-0 bg-accent text-xs">
                 2
@@ -112,17 +130,25 @@ const Header = () => {
             </Button>
 
             <div className="flex items-center gap-2">
-              <Button variant="outline" className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                className="flex items-center gap-2 cursor-pointer"
+                onClick={() => setSignInOpen(true)}
+              >
                 <User className="w-4 h-4" />
                 {t('header.signIn')}
               </Button>
-              <Button className="bg-primary hover:bg-primary/90">
+              <Button className="bg-primary hover:bg-primary/90 cursor-pointer" onClick={() => setSignUpOpen(true)}>
                 {t('header.signUp')}
               </Button>
             </div>
           </div>
         </div>
       </div>
+      <SignInModal open={isSignInOpen} onOpenChange={setSignInOpen} />
+      <SignUpModal open={isSignUpOpen} onOpenChange={setSignUpOpen} />
+      <CartSidebar open={isCartOpen} onOpenChange={setCartOpen} />
+      <NotificationsModal open={isNotificationsOpen} onOpenChange={setNotificationsOpen} />
     </header>
   );
 };

--- a/src/components/NotificationsModal.tsx
+++ b/src/components/NotificationsModal.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface NotificationsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const NotificationsModal = ({ open, onOpenChange }: NotificationsModalProps) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Notifications</DialogTitle>
+          <DialogDescription>
+            This is a placeholder notifications panel.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4">
+          <Button className="w-full" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NotificationsModal;

--- a/src/components/SignInModal.tsx
+++ b/src/components/SignInModal.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface SignInModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SignInModal = ({ open, onOpenChange }: SignInModalProps) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('header.signIn')}</DialogTitle>
+          <DialogDescription>
+            This is a placeholder sign in modal.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4">
+          <Button className="w-full" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SignInModal;

--- a/src/components/SignUpModal.tsx
+++ b/src/components/SignUpModal.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface SignUpModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SignUpModal = ({ open, onOpenChange }: SignUpModalProps) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('header.signUp')}</DialogTitle>
+          <DialogDescription>
+            This is a placeholder sign up modal.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4">
+          <Button className="w-full" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SignUpModal;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- add placeholder modals for sign in, sign up, notifications, and a cart sidebar
- update `Header` to open these modals and sidebar when clicking header buttons
- ensure buttons show the pointer cursor by default

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869db165c448320a117e6830943ab3c